### PR TITLE
lu: fix LU method decomposition

### DIFF
--- a/Matrix.hpp
+++ b/Matrix.hpp
@@ -71,10 +71,11 @@ void Matrix<T>::print()
     {
         for (unsigned int j = 0; j < _ncols; j++)
         {
-            std::cout << _matrix[i*_ncols+j] << " ";
+            std::cout << _matrix[i*_ncols+j] << "\t";
         }
         std::cout << std::endl;
     }
+    std::cout << std::endl;
 }
 
 #endif // MATRIX_H

--- a/Squarematrix.hpp
+++ b/Squarematrix.hpp
@@ -10,8 +10,20 @@ class SquareMatrix : public NumericMatrix<T> {
 public:
     SquareMatrix(const int size) : NumericMatrix<T>(size, size) {}
     const unsigned int getSize() { return this->getRowsCount(); }
-    void permute(const unsigned int startRow);
+
+    /**
+     * @brief Performs an LU decomposition of the given matrix inplace
+     *
+     */
     void lu();
+
+private:
+    /**
+     * @brief Given a startRow, it iterates forward looking for the max
+     * absolute value of a column in a rows range
+     *
+     */
+    void permute(const unsigned int startRow);
 };
 
 template <typename T>
@@ -21,7 +33,7 @@ void SquareMatrix<T>::permute(const unsigned int startRow)
   unsigned int maxValueRow = startRow;
 
   // Find the absolute max value of a column in a rows range(startRow:nRows)
-  for ( unsigned int currRow=startRow+1; currRow<this->getColumnsCount(); currRow++ )
+  for ( unsigned int currRow=startRow+1; currRow<getSize(); currRow++ )
   {
     if ( std::abs(this->get(currRow, startRow)) > maxValue ) {
       maxValue = std::abs(this->get(currRow, startRow));
@@ -32,7 +44,7 @@ void SquareMatrix<T>::permute(const unsigned int startRow)
   // Interchange row (startRow <-> maxValueRow)
   if ( maxValueRow != startRow ) {
     T tmp;
-    for ( unsigned int k=0; k<this->getColumnsCount(); k++ )
+    for ( unsigned int k=0; k<getSize(); k++ )
     {
       tmp = this->get(startRow, k);
       this->set(startRow, k, this->get(maxValueRow, k));
@@ -44,32 +56,22 @@ void SquareMatrix<T>::permute(const unsigned int startRow)
 template <typename T>
 void SquareMatrix<T>::lu()
 {
-  std::vector<T> L;
-  L.reserve(this->getColumnsCount()*this->getRowsCount());
   // Iterate through each column
-  for ( unsigned int col=0; col<this->getColumnsCount()-1; col++ )
+  for ( unsigned int col=0; col<getSize()-1; col++ )
   {
       permute(col);
       // Iterate through each row to do zero
-      for ( unsigned int row=col+1; row<this->getRowsCount(); row++ )
+      for ( unsigned int row=col+1; row<getSize(); row++ )
       {
           // Compute the pivot
           T p = static_cast<T>(-static_cast<T>(this->get(row, col))/static_cast<T>(this->get(col, col)));
           // Update row
-          for ( unsigned int k=col; k<this->getColumnsCount(); k++ )
+          for ( unsigned int k=col; k<getSize(); k++ )
           {
               this->set(row, k, this->get(row, k)+p*this->get(col, k));
           }
           // Store the pivot for L
-          L[row*this->getColumnsCount()+col] = -p;
-      }
-  }
-  for (unsigned int row = 1; row < this->getRowsCount(); row++)
-  {
-      // Update row
-      for (unsigned int col = 0; col < row; col++)
-      {
-          this->set(row, col, L[row*this->getColumnsCount()+col]);
+          this->set(row, col, -p);
       }
   }
 }

--- a/test/TestNumericMatrix.cpp
+++ b/test/TestNumericMatrix.cpp
@@ -58,6 +58,68 @@ TEST(NumericMatrix, checkInit)
   }
 }
 
+TEST(NumericMatrix, LU1)
+{
+  const size_t matrixSize = 3;
+  std::unique_ptr<SquareMatrix<NumericType>> matrix = std::make_unique<SquareMatrix<NumericType>>(matrixSize);
+  matrix->set(0, 0, 1);
+  matrix->set(0, 1, 2);
+  matrix->set(0, 2, 2);
+  matrix->set(1, 0, 4);
+  matrix->set(1, 1, 4);
+  matrix->set(1, 2, 2);
+  matrix->set(2, 0, 4);
+  matrix->set(2, 1, 6);
+  matrix->set(2, 2, 4);
+
+  matrix->print();
+
+  matrix->lu();
+
+  matrix->print();
+
+  EXPECT_NEAR(4, matrix->get(0, 0), 0.00001);
+  EXPECT_NEAR(4, matrix->get(0, 1), 0.00001);
+  EXPECT_NEAR(2, matrix->get(0, 2), 0.00001);
+  EXPECT_NEAR(1, matrix->get(1, 0), 0.00001);
+  EXPECT_NEAR(2, matrix->get(1, 1), 0.00001);
+  EXPECT_NEAR(2, matrix->get(1, 2), 0.00001);
+  EXPECT_NEAR(0.25, matrix->get(2, 0), 0.00001);
+  EXPECT_NEAR(0.5, matrix->get(2, 1), 0.00001);
+  EXPECT_NEAR(0.5, matrix->get(2, 2), 0.00001);
+}
+
+TEST(NumericMatrix, LU2)
+{
+  const size_t matrixSize = 3;
+  std::unique_ptr<SquareMatrix<NumericType>> matrix = std::make_unique<SquareMatrix<NumericType>>(matrixSize);
+  matrix->set(0, 0, 25);
+  matrix->set(0, 1, 5);
+  matrix->set(0, 2, 1);
+  matrix->set(1, 0, 64);
+  matrix->set(1, 1, 8);
+  matrix->set(1, 2, 1);
+  matrix->set(2, 0, 144);
+  matrix->set(2, 1, 12);
+  matrix->set(2, 2, 1);
+
+  matrix->print();
+
+  matrix->lu();
+
+  matrix->print();
+
+  EXPECT_NEAR(144, matrix->get(0, 0), 0.00001);
+  EXPECT_NEAR(12, matrix->get(0, 1), 0.00001);
+  EXPECT_NEAR(1, matrix->get(0, 2), 0.00001);
+  EXPECT_NEAR(0.17361, matrix->get(1, 0), 0.00001);
+  EXPECT_NEAR(2.91667, matrix->get(1, 1), 0.00001);
+  EXPECT_NEAR(0.82639, matrix->get(1, 2), 0.00001);
+  EXPECT_NEAR(0.44444, matrix->get(2, 0), 0.00001);
+  EXPECT_NEAR(0.91429, matrix->get(2, 1), 0.00001);
+  EXPECT_NEAR(-0.2, matrix->get(2, 2), 0.00001);
+}
+
 int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
L matrix was not being updated according P matrix. The permutations were not reflected since and L specific matrix was being used.
Now, L it's merged with U, so all values are stored in the same matrix and the permutations affect to all.